### PR TITLE
絞り込みしたコンテンツに対して、並べ替えができるように修正

### DIFF
--- a/resources/js/components/PostList.vue
+++ b/resources/js/components/PostList.vue
@@ -4,7 +4,7 @@
       <div class="col-4 col-md-4">
         <div class="container  sticky ">
         <!-- Search Form Column -->
-        <SearchForm @update-posts="handleUpdatePosts"/>
+         <SearchForm @update-keyword="searchKeyword = $event" @update-posts="handleUpdatePosts"/>
         
         <div style="height: 10px;"></div>
         <!-- Tag Selector Column -->
@@ -14,7 +14,7 @@
 
       <!-- Content Column -->
       <div class="col-8 col-md-8">
-        <SortButton  @update-posts="handleUpdatePosts"/>
+        <SortButton :selectedTags="selectedTags" :searchKeyword="searchKeyword" @update-posts="handleUpdatePosts"/>
         <PostCard v-for="post in posts" :key="post.id" :post="post" />
       </div>
     </div>
@@ -33,6 +33,7 @@ import _ from 'lodash';
 const posts = ref([]);
 const nextPageUrl = ref(null);
 const selectedTags = ref([]);
+const searchKeyword = ref('');
 const isLoading = ref(false);
 
 const fetchPosts = async () => {
@@ -73,6 +74,7 @@ const handleScroll = () => {
 };
 
 const handleUpdatePosts = (newData) => {
+  
   posts.value = newData.posts;
   nextPageUrl.value = newData.next_page_url;
 };

--- a/resources/js/components/SearchForm.vue
+++ b/resources/js/components/SearchForm.vue
@@ -25,6 +25,8 @@ const searchPosts = async () => {
     
   });
   //親コンポーネントへデータを送る
+  emit('update-keyword', keyword.value);
   emit('update-posts',response.data);
+  
 };
 </script>

--- a/resources/js/components/SortButton.vue
+++ b/resources/js/components/SortButton.vue
@@ -1,7 +1,7 @@
 <template>
 <div class="row">
     <div class="col-md-7 offset-md-4">
-        <form @submit.prevent="sortPosts" class="text-right">
+        <form  class="text-right">
             <span class="sort-label">並べ替え：</span>
             <a href="#" class="sort-link" @click.prevent="sort_new_Posts">新着順</a>
             <a href="#" class="sort-link" @click.prevent="sort_like_Posts">いいね順</a>
@@ -20,7 +20,11 @@
 import { ref } from 'vue';
 import axios from 'axios';
 
-const keyword = ref('');
+const props = defineProps({
+  selectedTags: Array,
+  searchKeyword: String
+});
+
 const emit = defineEmits(['update-posts']);
 
 
@@ -28,7 +32,10 @@ const emit = defineEmits(['update-posts']);
 
 const sort_new_Posts = async () => {
   const response = await axios.get('/api/posts', {
-    params: { orderBy: 'new' }
+    params: { orderBy: 'new' ,
+              tag: props.selectedTags,
+              keyword: props.searchKeyword
+              }
     
   });
   //親コンポーネントへデータを送る
@@ -38,7 +45,10 @@ const sort_new_Posts = async () => {
 
 const sort_like_Posts = async () => {
   const response = await axios.get('/api/posts', {
-    params: { orderBy: 'like' }
+    params: { orderBy: 'like',
+              tag: props.selectedTags,
+              keyword: props.searchKeyword
+              }
     
   });
   //親コンポーネントへデータを送る


### PR DESCRIPTION
修正前
タグやキーワードで絞り込みをした後
並べ替え機能を実行すると、すべての投稿を取得し、並べ替えたものを表示していた。

修正後
タグやキーワードで絞り込みをした後
並べ替え機能を実行すると、絞り込み取得した投稿の中で並べ替えしたものを表示するようになった。

具体的な変更内容
並べ替えを実行する際に、タグやキーワードをパラメータに含めてリクエストを送信するように変更。
そのために、コンポーネント間のpropsを設定した。
